### PR TITLE
Change the class of the sign in button and fix headless chrome

### DIFF
--- a/MusicLM.py
+++ b/MusicLM.py
@@ -82,14 +82,14 @@ class Music:
 
     def get_token(self):
         chrome_options = uc.ChromeOptions()
-        chrome_options.add_argument("--headless")
+        #chrome_options.add_argument("--headless")
         driver = uc.Chrome(options = chrome_options, use_subprocess=True, browser_executable_path=self.browser_executable_path, version_main=113) 
 
         try:
             driver.get(self.url)
 
             try:
-                WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.XPATH, "//button[contains(@class, 'ktZYzZ')]"))).click()
+                WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.XPATH, "//button[contains(@class, 'evTGAR')]"))).click()
 
                 WebDriverWait(driver, 20).until(EC.presence_of_element_located((By.XPATH, "//button[contains(@class, 'lgEhqE')]"))).click()
 


### PR DESCRIPTION
UC is having issues with headless chrome right now, so I omitted that line. Google also changed the class of the initial "Get Started" button so I changed that too.